### PR TITLE
fix: prim optimization regression. 

### DIFF
--- a/machine.cpp
+++ b/machine.cpp
@@ -279,6 +279,7 @@ void Machine::FirstPassOptimize()
 			{
 				logger::info("Packing Prim into GIFTAG");
 				CurrentBlock().prim = reg->Clone();
+				CurrentBlock().registers.remove(reg);
 				break;
 			}
 		}


### PR DESCRIPTION
When re-implementing registers to be unique_ptrs, I forgot to delete the prim in the list when packing the prim into the giftag.
This doesn't cause any issues, but made the prim packing optimization pointless.